### PR TITLE
remove unwanted optional fields in input

### DIFF
--- a/mona_openai/endpoints/chat_completion.py
+++ b/mona_openai/endpoints/chat_completion.py
@@ -60,7 +60,7 @@ class ChatCompletionWrapping(OpenAIEndpointWrappingLogic):
     def _get_endpoint_name(self):
         return CHAT_COMPLETION_CLASS_NAME
 
-    def get_clean_message(self, message: Mapping) -> Mapping:
+    def _internal_get_clean_message(self, message: Mapping) -> Mapping:
         """
         Returns a copy of the given message with relevant data removed, for
         example the actual texts, to avoid sending such information, that

--- a/mona_openai/endpoints/completion.py
+++ b/mona_openai/endpoints/completion.py
@@ -47,7 +47,7 @@ class CompletionWrapping(OpenAIEndpointWrappingLogic):
     def _get_endpoint_name(self) -> str:
         return COMPLETION_CLASS_NAME
 
-    def get_clean_message(self, message: Mapping) -> Mapping:
+    def _internal_get_clean_message(self, message: Mapping) -> Mapping:
         """
         Returns a copy of the given message with relevant data removed, for
         example the actual texts, to avoid sending such information, that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mona-openai"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
   { name="Itai Bar Sinai", email="itai@monalabs.io" },
 ]


### PR DESCRIPTION
Apparently, you can use the input request to specify your OpenAI secret - so we remove it to avoid sending it to Mona.